### PR TITLE
Улучшения в докер-обвязке бота

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .idea
 .env
 .env.*
+.cache/
+vendor/
 
 !.env.sample
 config/config.yml

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -1,5 +1,8 @@
 FROM golang:1.13-alpine AS pososyamba
 
+ENV GOPATH /application/vendor
+ENV HOME /application
+
 WORKDIR /application
 
 RUN apk update && apk upgrade && \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -11,7 +11,3 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
-
-RUN go build ./cmd/pososyamba_bot/main.go
-
-CMD [ "./main" ]

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,26 @@
-run_development:
-	docker-compose run --rm bot bash
+DOCKER_COMPOSE_RUN=docker-compose run bot
 
-build: Dockerfile
+build_image: Dockerfile
 	docker build --rm -f "Dockerfile" -t thesunwave/pososyamba:latest .
 
-run:
+run: build_image
 	docker run --env-file .env.development pososyamba:latest
+
+clean:
+	rm -f ./main
+
+build_container:
+	docker-compose build
+
+build_devel: build_container
+	${DOCKER_COMPOSE_RUN} "go build /application/cmd/pososyamba_bot/main.go"
+	chmod a+x ./main
+
+up: build_devel
+	docker-compose up
+
+down:
+	docker-compose down
+
+sh:
+	${DOCKER_COMPOSE_RUN} /bin/bash -l

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,23 @@
-DOCKER_COMPOSE_RUN=docker-compose run bot
+UID=$(shell id -u)
+USRENAME=`id -un`
+USER_PARAM=--user $(shell id -u):$(shell id -g)
+APP_VOLUME_PARAM=-v `pwd`/.:/application
+APP_PORT_PARAM=-p 80:3000/tcp
+CONTAINER_NAME=thesunwave/pososyamba:latest
+DOCKER_RUN=docker run -it ${USER_PARAM} ${APP_VOLUME_PARAM} ${APP_PORT_PARAM} ${CONTAINER_NAME}
+DOCKER_COMPOSE_RUN=docker-compose run  ${USER_PARAM}  bot
 
-build_image: Dockerfile
+build_prod: Dockerfile
 	docker build --rm -f "Dockerfile" -t thesunwave/pososyamba:latest .
 
-run: build_image
-	docker run --env-file .env.development pososyamba:latest
+run_prod: build_image
+	${DOCKER_RUN}--env-file .env.development
 
 clean:
 	rm -f ./main
 
-build_container:
-	docker-compose build
-
-build_devel: build_container
-	${DOCKER_COMPOSE_RUN} "go build /application/cmd/pososyamba_bot/main.go"
+build_devel: clean
+	${DOCKER_COMPOSE_RUN} /bin/sh -c "go build -work /application/cmd/pososyamba_bot/main.go"
 	chmod a+x ./main
 
 up: build_devel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.development
-    command: sh -c "go build /application/cmd/pososyamba_bot/main.go && /application/main"
+    command: /application/main
     depends_on:
       - redis
     env_file:


### PR DESCRIPTION
Предлагаю улучшения всего, что связано с запуском и разработкой  проекта в докере.

В первую очередь это более гранулярные типовые операции.
Во вторую, упрощение билда проекта от состояния "склонировал репу" до состояния "скомпилено и запущено".
Ну и прочие изменения.

Теперь детально.
Флоу развёртывания и разработки я разбил на следующие части:
1) build_prod && run_prod - две операции чтобы сбилдить готовый контейнер, готовый к пушу в докер хаб. в повседневной разработке не нужны

2) up && down / sh - основной флоу ежедневной разработки. up && down соответственно чтобы сбилдить свежую версию из кода, и тут же запустить её, down - останавливает и убивает контейнеры, чтобы не накапливались. полезен в случае глюков докера. 
sh - собственно открывает терминальную сессию внутри контейнера, для любых операций. не билдит код перед запуском. 

3) clean && build_devel - соответственно удаляют скомпилированный бинарник и компилят новый.

Что касается других изменений:
папку с модулями перенёс наружу контейнера, в /vendor. чтобы можно было делать поиск по коду прямо из IDE. 
(не уверен в необходимости этого решения)

сделана куча телодвижений чтобы файлы внутри контейнера принадлежали тому же юзеру, под которым ты работаешь снаружи. это решает проблемы когда докер (в котором всё от root'a по дефолту) понасозадёт файлов, а ты снаружи не можешь их изменить.